### PR TITLE
Simplify style

### DIFF
--- a/data/files.gresource.xml
+++ b/data/files.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/io/elementary/files/">
+    <file alias="ColorButton.css" compressed="true">styles/ColorButton.css</file>
+  </gresource>
+</gresources>

--- a/data/styles/ColorButton.css
+++ b/data/styles/ColorButton.css
@@ -1,0 +1,42 @@
+.color-button {
+    border: 1px solid alpha (#000, 0.3);
+    border-radius: 16px;
+    box-shadow:
+        inset 0 1px 0 0 alpha (@inset_dark_color, 0.7),
+        inset 0 0 0 1px alpha (@inset_dark_color, 0.3),
+        0 1px 0 0 alpha (@bg_highlight_color, 0.3);
+    min-height: 16px;
+    min-width: 16px;
+}
+
+.color-button.red {
+    background: @STRAWBERRY_300;
+}
+
+.color-button.orange {
+    background: @ORANGE_300;
+}
+
+.color-button.yellow {
+    background: @BANANA_500;
+}
+
+.color-button.green {
+    background: @LIME_500;
+}
+
+.color-button.blue {
+    background: @BLUEBERRY_500;
+}
+
+.color-button.purple {
+    background: @GRAPE_500;
+}
+
+.color-button.brown {
+    background: @COCOA_300;
+}
+
+.color-button.slate {
+    background: @SLATE_300;
+}

--- a/meson.build
+++ b/meson.build
@@ -100,6 +100,13 @@ project_config_dep = declare_dependency(
     include_directories: include_directories('.')
 )
 
+gnome = import('gnome')
+resources = gnome.compile_resources(
+    'files-resources', 'data/files.gresource.xml',
+    source_dir: 'data',
+    c_name: 'files'
+)
+
 subdir('libcore')
 subdir('libwidgets')
 subdir('src')

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -328,7 +328,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
         }
     }
 
-    private class ColorButton : Gtk.Button {
+    private class ColorButton : Gtk.Image {
         private const int BUTTON_WIDTH = 16;
         private const int BUTTON_HEIGHT = 16;
         private string color_name = "";
@@ -347,7 +347,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
                 border-top-right-radius: 16px;
                 border-bottom-right-radius: 16px;
                 text-shadow: 1px 1px transparent;
-                padding: 3px;
+                padding: 0;
             }
             .color-%s {
                 background-color: @%s\_300;
@@ -385,7 +385,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
         public signal void color_changed (int ncolor);
 
         construct {
-            set_size_request (150, 20);
+            set_size_request (150, 10);
             var css_provider = new Gtk.CssProvider ();
             string css = """
             .nohover:hover {
@@ -393,9 +393,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             }
             .cross-fix {
                 margin: 0;
-                padding: 1px;
-                margin-right: -8px;
-                margin-left: 1px;
+                padding: 0;
             }
             """;
 
@@ -411,12 +409,10 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
                 Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
             );
 
-            var color_button_remove = new Gtk.Button ();
-            color_button_remove.height_request = 8;
+            var color_button_remove = new Gtk.Image.from_icon_name ("window-close-symbolic", Gtk.IconSize.MENU);
             color_button_remove.width_request = 16;
             color_button_remove.get_style_context ().add_class ("flat");
             color_button_remove.get_style_context ().add_class ("cross-fix");
-            color_button_remove.set_image (new Gtk.Image.from_icon_name ("window-close-symbolic", Gtk.IconSize.MENU));
 
             var color_button_red = new ColorButton (1, "red", "STRAWBERRY");
             var color_button_orange = new ColorButton (2, "orange", "ORANGE");
@@ -427,6 +423,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             var color_button_slate = new ColorButton (7, "slate", "SLATE");
 
             var colorbox = new Gtk.Grid ();
+            colorbox.set_size_request (150, 10);
             colorbox.set_column_spacing (9);
             colorbox.margin_start = 3;
             colorbox.halign = Gtk.Align.START;

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -343,7 +343,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
 
         construct {
             var style_context = get_style_context ();
-            style_context.add_provider (css_provider,   Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            style_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
             style_context.add_class ("color-button");
             style_context.add_class (color_name);
         }

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -328,56 +328,24 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
         }
     }
 
-    private class ColorButton : Gtk.Image {
-        private const int BUTTON_WIDTH = 16;
-        private const int BUTTON_HEIGHT = 16;
-        private string color_name = "";
-        private string palette_name = "";
+    private class ColorButton : Gtk.Grid {
+        private static Gtk.CssProvider css_provider;
+        public string color_name { get; construct; }
 
-        public ColorButton (int id, string color_name, string palette_name) {
-            this.palette_name = palette_name;
-            this.color_name = color_name;
+        static construct {
+            css_provider = new Gtk.CssProvider ();
+            css_provider.load_from_resource ("io/elementary/files/ColorButton.css");
+        }
 
-            var css_provider = new Gtk.CssProvider ();
+        public ColorButton (int id, string color_name) {
+            Object (color_name: color_name);
+        }
 
-            string style = """
-            .color-button {
-                border-bottom-left-radius: 16px;
-                border-top-left-radius: 16px;
-                border-top-right-radius: 16px;
-                border-bottom-right-radius: 16px;
-                text-shadow: 1px 1px transparent;
-                padding: 0;
-            }
-            .color-%s {
-                background-color: @%s\_300;
-                border: 1px solid @%s\_500;
-            }
-            .color-%s:hover {
-                background-color: @%s\_100;
-                transition: all 100ms ease-out;
-            }
-            .nohover:hover {
-                background: @bg_color;
-            }
-            """.printf(color_name, palette_name, palette_name, color_name, palette_name);
-
-            try {
-                css_provider.load_from_data(style, -1);
-            } catch (GLib.Error e) {
-                warning ("Failed to parse css style : %s", e.message);
-            }
-
-            Gtk.StyleContext.add_provider_for_screen (
-                Gdk.Screen.get_default (),
-                css_provider,
-                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-            );
-
-            this.height_request = BUTTON_WIDTH;
-            this.width_request = BUTTON_HEIGHT;
-            this.get_style_context ().add_class ("color-button");
-            this.get_style_context ().add_class ("color-%s".printf(color_name));
+        construct {
+            var style_context = get_style_context ();
+            style_context.add_provider (css_provider,   Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            style_context.add_class ("color-button");
+            style_context.add_class (color_name);
         }
     }
 
@@ -414,13 +382,13 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             color_button_remove.get_style_context ().add_class ("flat");
             color_button_remove.get_style_context ().add_class ("cross-fix");
 
-            var color_button_red = new ColorButton (1, "red", "STRAWBERRY");
-            var color_button_orange = new ColorButton (2, "orange", "ORANGE");
-            var color_button_yellow = new ColorButton (3, "yellow", "BANANA");
-            var color_button_green = new ColorButton (4, "green", "LIME");
-            var color_button_blue = new ColorButton (5, "blue", "BLUEBERRY");
-            var color_button_violet = new ColorButton (6, "violet", "GRAPE");
-            var color_button_slate = new ColorButton (7, "slate", "SLATE");
+            var color_button_red = new ColorButton (1, "red");
+            var color_button_orange = new ColorButton (2, "orange");
+            var color_button_yellow = new ColorButton (3, "yellow");
+            var color_button_green = new ColorButton (4, "green");
+            var color_button_blue = new ColorButton (5, "blue");
+            var color_button_violet = new ColorButton (6, "purple");
+            var color_button_slate = new ColorButton (7, "slate");
 
             var colorbox = new Gtk.Grid ();
             colorbox.set_size_request (150, 10);

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -337,7 +337,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             css_provider.load_from_resource ("io/elementary/files/ColorButton.css");
         }
 
-        public ColorButton (int id, string color_name) {
+        public ColorButton (string color_name) {
             Object (color_name: color_name);
         }
 
@@ -382,13 +382,13 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             color_button_remove.get_style_context ().add_class ("flat");
             color_button_remove.get_style_context ().add_class ("cross-fix");
 
-            var color_button_red = new ColorButton (1, "red");
-            var color_button_orange = new ColorButton (2, "orange");
-            var color_button_yellow = new ColorButton (3, "yellow");
-            var color_button_green = new ColorButton (4, "green");
-            var color_button_blue = new ColorButton (5, "blue");
-            var color_button_violet = new ColorButton (6, "purple");
-            var color_button_slate = new ColorButton (7, "slate");
+            var color_button_red = new ColorButton ("red");
+            var color_button_orange = new ColorButton ("orange");
+            var color_button_yellow = new ColorButton ("yellow");
+            var color_button_green = new ColorButton ("green");
+            var color_button_blue = new ColorButton ("blue");
+            var color_button_violet = new ColorButton ("purple");
+            var color_button_slate = new ColorButton ("slate");
 
             var colorbox = new Gtk.Grid ();
             colorbox.set_size_request (150, 10);

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,6 +9,7 @@ pantheon_files_deps = [
 
 pantheon_files_exec = executable (
     meson.project_name (),
+    resources,
     'main.vala',
 
     'Application.vala',


### PR DESCRIPTION
This does a few things:

* Moves styles into their own file which is nice because we get syntax highlighting and all that good stuff
* Loads styles from a gresource which doesn't require a try/catch like loading from data does
* Creates the CSS provider in a static constructor which means only one provider is created for every instance instead of one provider being created for each instance. So that's 7x fewer style providers being created.
* Saves us passing in an extra argument to the ColorButton class since styles are fully defined in the stylesheet
* Sets widget size in the stylesheet
* Caches that style context so we get it once instead of 3x
* Applies the style context only to the widget being styled so that styles don't ever accidentally leak out to other widgets