### PR TITLE
Use Checks

### DIFF
--- a/data/styles/ColorButton.css
+++ b/data/styles/ColorButton.css
@@ -1,18 +1,18 @@
-.color-button radio,
-.color-button radio:checked {
+.color-button check,
+.color-button check:checked {
     border: 1px solid @border_color;
     border-radius: 12px;
     box-shadow:
         inset 0 1px 0 0 alpha (@inset_dark_color, 0.7),
         inset 0 0 0 1px alpha (@inset_dark_color, 0.3),
         0 1px 0 0 alpha (@bg_highlight_color, 0.3);
-    min-height: 11px;
-    min-width: 11px;
+    min-height: 10px;
+    min-width: 10px;
     padding: 3px;
     -gtk-icon-shadow: none;
 }
 
-.color-button.white radio {
+.color-button.white check {
     background: @base_color;
     color: mix (@text_color, @base_color, 0.5);
     min-height: 16px;
@@ -21,34 +21,34 @@
     -gtk-icon-source: -gtk-icontheme("close-symbolic");
 }
 
-.color-button.red radio {
+.color-button.red check {
     background: @STRAWBERRY_300;
 }
 
-.color-button.orange radio {
+.color-button.orange check {
     background: @ORANGE_300;
 }
 
-.color-button.yellow radio {
+.color-button.yellow check {
     background: @BANANA_500;
 }
 
-.color-button.green radio {
+.color-button.green check {
     background: @LIME_500;
 }
 
-.color-button.blue radio {
+.color-button.blue check {
     background: @BLUEBERRY_500;
 }
 
-.color-button.purple radio {
+.color-button.purple check {
     background: @GRAPE_500;
 }
 
-.color-button.brown radio {
+.color-button.brown check {
     background: @COCOA_300;
 }
 
-.color-button.slate radio {
+.color-button.slate check {
     background: @SLATE_300;
 }

--- a/data/styles/ColorButton.css
+++ b/data/styles/ColorButton.css
@@ -1,42 +1,54 @@
-.color-button {
-    border: 1px solid alpha (#000, 0.3);
-    border-radius: 16px;
+.color-button radio,
+.color-button radio:checked {
+    border: 1px solid @border_color;
+    border-radius: 12px;
     box-shadow:
         inset 0 1px 0 0 alpha (@inset_dark_color, 0.7),
         inset 0 0 0 1px alpha (@inset_dark_color, 0.3),
         0 1px 0 0 alpha (@bg_highlight_color, 0.3);
-    min-height: 16px;
-    min-width: 16px;
+    min-height: 11px;
+    min-width: 11px;
+    padding: 3px;
+    -gtk-icon-shadow: none;
 }
 
-.color-button.red {
+.color-button.white radio {
+    background: @base_color;
+    color: mix (@text_color, @base_color, 0.5);
+    min-height: 16px;
+    min-width: 16px;
+    padding: 1px;
+    -gtk-icon-source: -gtk-icontheme("close-symbolic");
+}
+
+.color-button.red radio {
     background: @STRAWBERRY_300;
 }
 
-.color-button.orange {
+.color-button.orange radio {
     background: @ORANGE_300;
 }
 
-.color-button.yellow {
+.color-button.yellow radio {
     background: @BANANA_500;
 }
 
-.color-button.green {
+.color-button.green radio {
     background: @LIME_500;
 }
 
-.color-button.blue {
+.color-button.blue radio {
     background: @BLUEBERRY_500;
 }
 
-.color-button.purple {
+.color-button.purple radio {
     background: @GRAPE_500;
 }
 
-.color-button.brown {
+.color-button.brown radio {
     background: @COCOA_300;
 }
 
-.color-button.slate {
+.color-button.slate radio {
     background: @SLATE_300;
 }

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -379,36 +379,25 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             var color_button_remove = new ColorButton ("white");
 
             color_button_red = new ColorButton ("red");
-            var color_button_orange = new ColorButton ("orange");
-            var color_button_yellow = new ColorButton ("yellow");
-            var color_button_green = new ColorButton ("green");
-            var color_button_blue = new ColorButton ("blue");
-            var color_button_violet = new ColorButton ("purple");
-            var color_button_brown = new ColorButton ("brown");
-            var color_button_slate = new ColorButton ("slate");
 
             color_buttons = new Gee.ArrayList<ColorButton> ();
             color_buttons.add (color_button_red);
-            color_buttons.add (color_button_orange);
-            color_buttons.add (color_button_yellow);
-            color_buttons.add (color_button_green);
-            color_buttons.add (color_button_blue);
-            color_buttons.add (color_button_violet);
-            color_buttons.add (color_button_brown);
-            color_buttons.add (color_button_slate);
+            color_buttons.add (new ColorButton ("orange"));
+            color_buttons.add (new ColorButton ("yellow"));
+            color_buttons.add (new ColorButton ("green"));
+            color_buttons.add (new ColorButton ("blue"));
+            color_buttons.add (new ColorButton ("purple"));
+            color_buttons.add (new ColorButton ("brown"));
+            color_buttons.add (new ColorButton ("slate"));
 
             var colorbox = new Gtk.Grid ();
             colorbox.column_spacing = COLORBOX_SPACING;
             colorbox.margin_start = 3;
             colorbox.halign = Gtk.Align.START;
             colorbox.add (color_button_remove);
-            for (int i = 0; i < color_buttons.size; i++) {
-	                colorbox.add (color_buttons[i]);
-	            }
 
-            color_buttons = new Gee.ArrayList<ColorButton> ();
-            foreach (Gtk.Widget? button in colorbox.get_children ()) {
-                color_buttons.add ((ColorButton) button);
+            for (int i = 0; i < color_buttons.size; i++) {
+                colorbox.add (color_buttons[i]);
             }
 
             add (colorbox);

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -371,7 +371,6 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
         public signal void color_changed (int ncolor);
 
         private Gee.ArrayList<ColorButton> color_buttons;
-
         private ColorButton color_button_red;
         private const int COLORBOX_SPACING = 3;
 


### PR DESCRIPTION
![Screenshot from 2019-06-19 11 15 39@2x](https://user-images.githubusercontent.com/7277719/59789940-b1086800-9283-11e9-8637-7ed1fff5338e.png)

* Use Checks for ColorButton
* Only apply nohover CSS to the menuitem widget
* Get ColorButton width from `get_allocated_width` so that it's accurate
* Replace magic numbers with constants or variables for clarity and remove confusing comment