### PR TITLE
Small fixes

### DIFF
--- a/data/styles/ColorButton.css
+++ b/data/styles/ColorButton.css
@@ -12,7 +12,7 @@
     -gtk-icon-shadow: none;
 }
 
-.color-button.white check {
+.color-button.none check {
     background: @base_color;
     color: mix (@text_color, @base_color, 0.5);
     min-height: 16px;

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -446,7 +446,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             } else {
                 int x = 27;
                 for (int i = 0; i < GOF.Preferences.TAGS_COLORS.length; i++) {
-                    if (event.x >= x && event.x <= x + 16) {
+                    if (event.x >= x && event.x <= x + color_button_width) {
                         color_changed (i);
                         clear_checks ();
                         check_color (i);

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -359,16 +359,12 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
         public signal void color_changed (int ncolor);
 
         private Gee.ArrayList<ColorButton> color_buttons;
-        private ColorButton color_button_red;
         private const int COLORBOX_SPACING = 3;
 
         construct {
             var color_button_remove = new ColorButton ("none");
-
-            color_button_red = new ColorButton ("red");
-
             color_buttons = new Gee.ArrayList<ColorButton> ();
-            color_buttons.add (color_button_red);
+            color_buttons.add (new ColorButton ("red"));
             color_buttons.add (new ColorButton ("orange"));
             color_buttons.add (new ColorButton ("yellow"));
             color_buttons.add (new ColorButton ("green"));
@@ -421,7 +417,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
         }
 
         private bool button_pressed_cb (Gdk.EventButton event) {
-            var color_button_width = color_button_red.get_allocated_width ();
+            var color_button_width = color_buttons[0].get_allocated_width ();
 
             int y0 = (get_allocated_height () - color_button_width) / 2;
             int x0 = COLORBOX_SPACING + color_button_width;

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -363,7 +363,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
         private const int COLORBOX_SPACING = 3;
 
         construct {
-            var color_button_remove = new ColorButton ("white");
+            var color_button_remove = new ColorButton ("none");
 
             color_button_red = new ColorButton ("red");
 


### PR DESCRIPTION
Just some minor code fixes.  

* color_button_width was used for RTL but hard-coded value for LTR - uses variable for both.
* the color-name "white" for the remove button is not strictly accurate as in dark themes the background is not white.  Changed to "none" as there is no color tag and the theme background is used.
* It is not necessary to keep a separate reference to one of the buttons.
